### PR TITLE
Enable stable

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -9,6 +9,7 @@ xdebug_enabled: false
 additional_hostnames: []
 additional_fqdns: []
 mariadb_version: "10.3"
+nfs_mount_enabled: true
 provider: default
 use_dns_when_possible: true
 

--- a/config/drupal/core.extension.yml
+++ b/config/drupal/core.extension.yml
@@ -55,6 +55,7 @@ theme:
   seven: 0
   bglobal: 0
   stark: 0
+  stable: 0
 profile: minimal
 _core:
   default_config_hash: R4IF-ClDHXxblLcG0L7MgsLvfBIMAvi_skumNFQwkDc


### PR DESCRIPTION
This PR enables Stable theme and addes nfs mount true to ddev.

## Testing Instructions
- Follow first time setup instructions on the README by running `setup.sh` script.
- Confirm that the config import works without errors.
- Visit the local site - log in, and confirm that the admin theme is working properly if you visit admin pages such as https://global.ddev.site/admin/structure.
- Make sure Bartik theme is applied to the regular page.
<img width="800" alt="Screen Shot 2020-09-23 at 1 37 13 PM" src="https://user-images.githubusercontent.com/10488517/94054963-e9112b80-fda1-11ea-8921-f7fcfdd950c1.png">
