### PR TITLE
On refresh, copy settings files.

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -12,6 +12,7 @@ mariadb_version: "10.3"
 nfs_mount_enabled: true
 use_dns_when_possible: true
 provider: default
+disable_settings_management: true
 hooks:
   post-start:
   - exec: echo 'Copying configuration files...'

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -10,13 +10,17 @@ additional_hostnames: []
 additional_fqdns: []
 mariadb_version: "10.3"
 nfs_mount_enabled: true
-provider: default
 use_dns_when_possible: true
+provider: default
+hooks:
+  post-start:
+  - exec: echo 'Copying configuration files...'
+  - exec: cp /var/www/html/config/settings/settings.ddev.php /var/www/html/web/sites/default
+  - exec: cp /var/www/html/config/settings/development.services.yml /var/www/html/web/sites
 
-
-# This config.yaml was created with ddev version v1.14.2
-# webimage: drud/ddev-webserver:v1.14.2
-# dbimage: drud/ddev-dbserver-mariadb-10.2:v1.14.1
+# This config.yaml was created with ddev version v1.15.3
+# webimage: drud/ddev-webserver:v1.15.3
+# dbimage: drud/ddev-dbserver-mariadb-10.2:v1.15.1
 # dbaimage: phpmyadmin/phpmyadmin:5
 # However we do not recommend explicitly wiring these images into the
 # config.yaml as they may break future versions of ddev.
@@ -85,7 +89,7 @@ use_dns_when_possible: true
 # These values specify the destination directory for ddev ssh and the
 # directory in which commands passed into ddev exec are run.
 
-# omit_containers: ["db", dba", "ddev-ssh-agent"]
+# omit_containers: [db, dba, ddev-ssh-agent]
 # Currently only these containers are supported. Some containers can also be
 # omitted globally in the ~/.ddev/global_config.yaml. Note that if you omit
 # the "db" container, several standard features of ddev that access the
@@ -119,7 +123,7 @@ use_dns_when_possible: true
 # mailhog_https_port: "8026"
 # The MailHog ports can be changed from the default 8025 and 8026
 
-# webimage_extra_packages: [php-yaml, php7.3-ldap]
+# webimage_extra_packages: [php7.3-tidy, php-bcmath]
 # Extra Debian packages that are needed in the webimage can be added here
 
 # dbimage_extra_packages: [telnet,netcat]
@@ -147,9 +151,9 @@ use_dns_when_possible: true
 # In this case the user must provide all such settings.
 
 # no_project_mount: false
-# (Experimental) If true, ddev will not mount the project into the web container; 
+# (Experimental) If true, ddev will not mount the project into the web container;
 # the user is responsible for mounting it manually or via a script.
-# This is to enable experimentation with alternate file mounting strategies. 
+# This is to enable experimentation with alternate file mounting strategies.
 # For advanced users only!
 
 # provider: default # Currently either "default" or "pantheon"

--- a/config/settings/settings.ddev.php
+++ b/config/settings/settings.ddev.php
@@ -53,3 +53,8 @@ elseif (empty($settings['config_sync_directory'])) {
 
 // Use correct services.yml file for twig debugging during development.
 $settings['container_yamls'][] = DRUPAL_ROOT . '/sites/default/development.services.yml';
+$config['system.performance']['css']['preprocess'] = FALSE;
+$config['system.performance']['js']['preprocess'] = FALSE;
+$settings['cache']['bins']['page'] = 'cache.backend.null';
+$settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
+$settings['cache']['bins']['render'] = 'cache.backend.null';

--- a/scripts/refresh.sh
+++ b/scripts/refresh.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # be in the right directory
 cd /var/www/html/web
+echo 'Copying settings file...'
+cp ../config/settings/settings.ddev.php sites/default
+echo 'Copying development settings file...'
+cp ../config/settings/development.services.yml sites/default
 echo 'Clearing cache...'
 drush cr
 echo 'Importing configuration...'

--- a/scripts/refresh.sh
+++ b/scripts/refresh.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 # be in the right directory
 cd /var/www/html/web
-echo 'Copying settings file...'
-cp ../config/settings/settings.ddev.php sites/default
-echo 'Copying development settings file...'
-cp ../config/settings/development.services.yml sites/default
 echo 'Clearing cache...'
 drush cr
 echo 'Importing configuration...'


### PR DESCRIPTION
Fixes the refresh.sh script to place the proper config files in place before import.

# Testing instructions

- Checkout this branch
- From the host machine:
  - `ddev stop`
  - `ddev start`
- Check that the file `web/sites/development.services.yml` is identical to `config/settings/development.services.yml`
- Check that the file `web/sites/default/settings.ddev.php` is identical to `config/settings/settings.ddev.php`
- `ddev ssh`
- `drush cex` -- check that it tries to export to `../config/drupal` -- do not export config changes.
- Load https://global.ddev.site/
- Confirm that `<!-- THEME DEBUG -->` output is present in the HTML.