### PR TITLE
Moving npm install for pdb_ng2 from setup.sh composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,5 +108,10 @@
         "Drupal 9 readiness (https://www.drupal.org/project/term_condition/issues/3133793)": "https://www.drupal.org/files/issues/2020-05-13/3133793-11.patch"
       }
     }
+  },
+  "scripts": {
+    "post-install-cmd": [
+        "cd web/modules/contrib/pdb/modules/pdb_ng2 && npm install"
+    ]
   }
 }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-echo 'Installing Angular elements...'
-cd /var/www/html/web/modules/contrib/pdb/modules/pdb_ng2
-npm install 2>/dev/null
 # be in the right directory
 cd /var/www/html
 echo 'Copying settings file...'


### PR DESCRIPTION
## Description
#21 wasn't working for me because the node_modules folder was missing from the pdb_ng2 folder. `npm install` couldn't be run from within the virtual machine so the setup.sh "Installing Angular" section wasn't working.

I thought of moving the `npm install` to composer.json since that runs outside of the virtual machine. I have a feeling this might not be ideal, but running the testing instructions with this edit makes the Voices Posts show up.

## Testing instructions

* Checkout this branch
* From project root, run `composer install`
* Check that the `pdb` module downloaded properly.
* SSH into DDEV `ddev ssh`
* Run `../scripts/setup.sh` to re-install Drupal
  * Observe the 'Installing Angular elements...' step
* Go to https://global.ddev.site/ 
 * Observe the `Voices Post List` block is displayed on the homepage and has content.
* Login using `drush uli`
* Observe that the `bglobal_angular` module is enabled.
* Go to https://global.ddev.site/admin/structure/block
* Observe that the `Angular: Voices Post List` block is enabled in the Content section.