### PR TITLE
Configure pardot

### DIFF
--- a/config/drupal/block.block.custompardotform.yml
+++ b/config/drupal/block.block.custompardotform.yml
@@ -17,4 +17,19 @@ settings:
   label: 'Custom Pardot form'
   provider: bglobal_pardot
   label_display: visible
+  action_url: 'https://go.pardot.com/l/102272/2016-11-04/2klckm'
+  success_location: 'https://extension.berkeley.edu/international/asdasd'
+  error_location: 'https://extension.berkeley.edu/international/'
+  field_list:
+    firstname: firstname
+    lastname: lastname
+    email: email
+    question: question
+    opt_in_contact: opt_in_contact
+  submit_label: 'Apply Now'
+  success_message: 'Success message...'
+  tracking_fields:
+    full_path: full_path
+    page_title: page_title
+    program_name: 0
 visibility: {  }

--- a/config/drupal/block.block.custompardotform.yml
+++ b/config/drupal/block.block.custompardotform.yml
@@ -17,23 +17,19 @@ settings:
   label: 'Custom Pardot form'
   provider: bglobal_pardot
   label_display: visible
-  # What does adding the fields here do? 
-  # As I was debugging/learning I removed these and 
-  # it didn't seem to affect it
-  # 
-  # action_url: 'https://go.pardot.com/l/102272/2016-11-04/2klckm'
-  # success_location: 'https://extension.berkeley.edu/international/asdasd'
-  # error_location: 'https://extension.berkeley.edu/international/'
-  # field_list:
-  #   firstname: firstname
-  #   lastname: lastname
-  #   email: email
-  #   question: question
-  #   opt_in_contact: opt_in_contact
-  # submit_label: 'Apply Now'
-  # success_message: 'Success message...'
-  # tracking_fields:
-  #   full_path: full_path
-  #   page_title: page_title
-  #   program_name: 0
+  action_url: 'https://go.pardot.com/l/102272/2016-11-04/2klckm'
+  success_location: 'https://extension.berkeley.edu/international/'
+  error_location: 'https://extension.berkeley.edu/international/'
+  field_list:
+    firstname: firstname
+    lastname: lastname
+    email: email
+    question: question
+    opt_in_contact: opt_in_contact
+  submit_label: 'Apply Now'
+  success_message: 'Success message...'
+  tracking_fields:
+    full_path: full_path
+    page_title: page_title
+    program_name: 0
 visibility: {  }

--- a/config/drupal/block.block.custompardotform.yml
+++ b/config/drupal/block.block.custompardotform.yml
@@ -17,19 +17,23 @@ settings:
   label: 'Custom Pardot form'
   provider: bglobal_pardot
   label_display: visible
-  action_url: 'https://go.pardot.com/l/102272/2016-11-04/2klckm'
-  success_location: 'https://extension.berkeley.edu/international/asdasd'
-  error_location: 'https://extension.berkeley.edu/international/'
-  field_list:
-    firstname: firstname
-    lastname: lastname
-    email: email
-    question: question
-    opt_in_contact: opt_in_contact
-  submit_label: 'Apply Now'
-  success_message: 'Success message...'
-  tracking_fields:
-    full_path: full_path
-    page_title: page_title
-    program_name: 0
+  # What does adding the fields here do? 
+  # As I was debugging/learning I removed these and 
+  # it didn't seem to affect it
+  # 
+  # action_url: 'https://go.pardot.com/l/102272/2016-11-04/2klckm'
+  # success_location: 'https://extension.berkeley.edu/international/asdasd'
+  # error_location: 'https://extension.berkeley.edu/international/'
+  # field_list:
+  #   firstname: firstname
+  #   lastname: lastname
+  #   email: email
+  #   question: question
+  #   opt_in_contact: opt_in_contact
+  # submit_label: 'Apply Now'
+  # success_message: 'Success message...'
+  # tracking_fields:
+  #   full_path: full_path
+  #   page_title: page_title
+  #   program_name: 0
 visibility: {  }

--- a/web/modules/custom/bglobal_pardot/bglobal_pardot.module
+++ b/web/modules/custom/bglobal_pardot/bglobal_pardot.module
@@ -1,4 +1,5 @@
 <?php
+use Drupal\Core\Url;
 
 /**
  * @file
@@ -21,6 +22,8 @@ function bglobal_pardot_theme() {
           'page_title',
           'program_name',
           'full_path',
+          'success_location',
+          'error_location',
         ],
       ],
     ),
@@ -83,10 +86,13 @@ function bglobal_pardot_trackers() {
     $page_title = 'Berkeley Global';
   }
 
+  $current_url = Url::fromRoute('<current>', [], ['query' => \Drupal::request()->query->all(), 'absolute' => 'true'])->toString();
   $trackers = [
     'full_path' => 'This value needs to be derived from local storage and set as a script target object.',
     'page_title' => $page_title,
     'program_name' => '',
+    'success_location' => $current_url . "?thankyou=welcome",
+    'error_location' => $current_url . "?thankyou=false",
   ];
 
   return $trackers;

--- a/web/modules/custom/bglobal_pardot/bglobal_pardot.module
+++ b/web/modules/custom/bglobal_pardot/bglobal_pardot.module
@@ -79,6 +79,9 @@ function bglobal_pardot_trackers() {
     $request = \Drupal::request();
     $page_title = $title_resolver->getTitle($request, $route);
   }
+  if (empty($page_title)) {
+    $page_title = 'Berkeley Global';
+  }
 
   $trackers = [
     'full_path' => 'This value needs to be derived from local storage and set as a script target object.',

--- a/web/modules/custom/bglobal_pardot/src/Plugin/Block/PardotFormBlock.php
+++ b/web/modules/custom/bglobal_pardot/src/Plugin/Block/PardotFormBlock.php
@@ -32,25 +32,59 @@ class PardotFormBlock extends BlockBase {
     $form['urls'] = [
       '#type' => 'details',
       '#title' => $this->t('Form URLs'),
-      '#open' => TRUE,
+      '#open' => FALSE,
     ];
     $form['urls']['action_url'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Form Action URL'),
-      '#default_value' => $this->getDefaultValue('action_url'),
+      '#default_value' => $this->configuration['action_url'],
       '#description' => $this->t('The Pardot form URL'),
     ];
     $form['urls']['success_location'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Success Location URL'),
-      '#default_value' => $this->getDefaultValue('success_location'),
+      '#default_value' => $this->configuration['success_location'],
       '#description' => $this->t('The URL to redirect to after form completion.'),
     ];
     $form['urls']['error_location'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Error Location URL'),
-      '#default_value' => $this->getDefaultValue('error_location'),
+      '#default_value' => $this->configuration['error_location'],
       '#description' => $this->t('The URL to redirect to on form failure.'),
+    ];
+    $form['fields'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Pardot Fields'),
+      '#open' => TRUE,
+    ];
+    $form['fields']['field_list'] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Included fields'),
+      '#default_value' => $this->configuration['field_list'],
+      '#options' => $this->getFieldOptions(),
+    ];
+    $form['fields']['tracking_fields'] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Hidden tracking fields'),
+      '#default_value' => $this->configuration['tracking_fields'],
+      '#options' => $this->getTrackingOptions(),
+    ];
+    $form['interface'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Interface options'),
+      '#open' => TRUE,
+    ];
+    $form['interface']['submit_label'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Submit button label'),
+      '#default_value' => $this->configuration['submit_label'],
+      '#description' => $this->t('The label for the submit button.'),
+    ];
+    $form['interface']['success_message'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Success message'),
+      '#default_value' => $this->configuration['success_message'],
+      '#description' => $this->t('Message to display after form submission.'),
     ];
     return $form;
   }
@@ -62,6 +96,10 @@ class PardotFormBlock extends BlockBase {
     $this->configuration['action_url'] = $form_state->getValue(['urls', 'action_url']);
     $this->configuration['success_location'] = $form_state->getValue(['urls', 'success_location']);
     $this->configuration['error_location'] = $form_state->getValue(['urls', 'error_location']);
+    $this->configuration['field_list'] = $form_state->getValue(['fields', 'field_list']);
+    $this->configuration['tracking_fields'] = $form_state->getValue(['fields', 'tracking_fields']);
+    $this->configuration['submit_label'] = $form_state->getValue(['interface', 'submit_label']);
+    $this->configuration['success_message'] = $form_state->getValue(['interface', 'success_message']);
   }
 
   /**
@@ -72,25 +110,77 @@ class PardotFormBlock extends BlockBase {
       'action_url' => 'https://go.pardot.com/l/102272/2016-11-04/2klckm',
       'success_location' => 'https://extension.berkeley.edu/international/',
       'error_location' => 'https://extension.berkeley.edu/international/',
-      'field_list' => [],
+      'field_list' => [
+        'firstname' => 'firstname',
+        'lastname' => 'lastname',
+        'email' => 'email',
+        'question' => 'question',
+      ],
       'submit_label' => $this->t('Submit'),
-      'tracking_fields' => [],
+      'success_message' => $this->t('Success message...'),
+      'tracking_fields' => [
+        'full_path' => 'full_path',
+        'page_title' => 'page_title',
+      ],
     ];
   }
 
   /**
-   * Returns the default value for a field,
-   *
-   * @param $field
-   *   The configuration field name.
-   *
-   * @return mixed
-   *   The value of the field as configured, or its default value.
+   * Returns the list of available fields.
    */
-  public function getDefaultValue($field) {
-    $defaults = $this->defaultConfiguration();
-    $value = $this->configuration[$field] ?: $defaults[$field];
-    return $value;
+  public function getFieldOptions() {
+    return [
+      'firstname' => 'firstname',
+      'lastname' => 'lastname',
+      'email' => 'email',
+      'question' => 'question',
+      'opt_in_contact' => 'opt_in_contact',
+    ];
+  }
+
+  /**
+   * Returns the list of available trackers.
+   */
+  public function getTrackingOptions() {
+    return [
+      'full_path' => 'full_path',
+      'page_title' => 'page_title',
+      'program_name' => 'program_name',
+    ];
+  }
+
+  public function defaultFieldSettings() {
+    $field_settings = [
+      'firstname' => [
+        'label' => 'First Name',
+        'type' => 'text',
+        'required' => TRUE,
+      ],
+      'lastname' => [
+        'label' => 'Last Name',
+        'type' => 'text',
+        'required' => TRUE,
+      ],
+      'email' => [
+        'label' => 'Email',
+        'type' => 'text',
+        'required' => TRUE,
+      ],
+      'question' => [
+        'label' => 'Question',
+        'type' => 'textarea',
+        'rows' => '5',
+        'cols' => '20',
+        'required' => FALSE,
+      ],
+      'opt_in_contact' => [
+        'label' => 'Contact List',
+        'type' => 'checkbox',
+        'description' => 'Join our mailing list.',
+        'required' => FALSE,
+      ],
+    ];
+    return $field_settings;
   }
 
   /**
@@ -99,59 +189,25 @@ class PardotFormBlock extends BlockBase {
   public function build() {
     $build = [
       '#theme' => 'bglobal_pardot_form',
-      '#action_url' => 'https://go.pardot.com/l/102272/2016-11-04/2klckm',
-      '#success_message' => 'Success!',
-      '#submit_label' => 'Act Now!',
-      '#fields' => [
-        'firstname' => [
-          'label' => 'First Name',
-          'type' => 'text',
-          'required' => TRUE,
-        ],
-        'lastname' => [
-          'label' => 'Last Name',
-          'type' => 'text',
-          'required' => TRUE,
-        ],
-        'email' => [
-          'label' => 'Email',
-          'type' => 'text',
-          'required' => TRUE,
-        ],
-        'status' => [
-          'label' => 'Status',
-          'type' => 'select',
-          'options' => ['Student', 'Professional'],
-          'default_value' => 'Professional',
-        ],
-        'question' => [
-          'label' => 'Question',
-          'type' => 'textarea',
-          'rows' => '5',
-          'cols' => '20',
-          'required' => FALSE,
-        ],
-        'opt_in_contact' => [
-          'label' => 'Contact List',
-          'type' => 'checkbox',
-          'description' => 'Join our mailing list.',
-          'required' => FALSE,
-        ],
-        'success_location' => [
-          'type' => 'hidden',
-          'default_value' => 'https://extension.berkeley.edu/international/',
-        ],
-        'error_location' => [
-          'type' => 'hidden',
-          'default_value' => 'https://extension.berkeley.edu/international/',
-        ],
-      ],
-      '#tracking' => [
-        'page_title',
-        #'program_name',
-        'full_path',
-      ],
+      '#action_url' => $this->configuration['action_url'],
+      '#success_location' => $this->configuration['success_location'],
+      '#error_location' => $this->configuration['error_location'],
+      '#success_message' => $this->configuration['success_message'],
+      '#submit_label' => $this->configuration['submit_label'],
     ];
+    $fields = $this->configuration['field_list'];
+    $field_settings = $this->defaultFieldSettings();
+    foreach ($field_settings as $key => $value) {
+      if (!empty($fields[$key])) {
+        $build['#fields'][$key] = $value;
+      }
+    }
+    $tracking = $this->configuration['tracking_fields'];
+    foreach ($tracking as $key => $value) {
+      if (!empty($value)) {
+        $build['#tracking'][] = $key;
+      }
+    }
     $build['#attached']['library'][] = 'bglobal_pardot/drupal.bglobal_pardot';
 
     return $build;

--- a/web/modules/custom/bglobal_pardot/src/Plugin/Block/PardotFormBlock.php
+++ b/web/modules/custom/bglobal_pardot/src/Plugin/Block/PardotFormBlock.php
@@ -58,16 +58,10 @@ class PardotFormBlock extends BlockBase {
   /**
    * {@inheritdoc}
    */
-  public function blockValidate($form, FormStateInterface $form_state) {
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function blockSubmit($form, FormStateInterface $form_state) {
-    foreach (array_keys($this->defaultConfiguration()) as $element) {
-      $this->configuration[$element] = $form_state->getValue($element);
-    }
+    $this->configuration['action_url'] = $form_state->getValue(['urls', 'action_url']);
+    $this->configuration['success_location'] = $form_state->getValue(['urls', 'success_location']);
+    $this->configuration['error_location'] = $form_state->getValue(['urls', 'error_location']);
   }
 
   /**

--- a/web/modules/custom/bglobal_pardot/src/Plugin/Block/PardotFormBlock.php
+++ b/web/modules/custom/bglobal_pardot/src/Plugin/Block/PardotFormBlock.php
@@ -40,18 +40,6 @@ class PardotFormBlock extends BlockBase {
       '#default_value' => $this->configuration['action_url'],
       '#description' => $this->t('The Pardot form URL'),
     ];
-    $form['urls']['success_location'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Success Location URL'),
-      '#default_value' => $this->configuration['success_location'],
-      '#description' => $this->t('The URL to redirect to after form completion.'),
-    ];
-    $form['urls']['error_location'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Error Location URL'),
-      '#default_value' => $this->configuration['error_location'],
-      '#description' => $this->t('The URL to redirect to on form failure.'),
-    ];
     $form['fields'] = [
       '#type' => 'details',
       '#title' => $this->t('Pardot Fields'),
@@ -94,8 +82,6 @@ class PardotFormBlock extends BlockBase {
    */
   public function blockSubmit($form, FormStateInterface $form_state) {
     $this->configuration['action_url'] = $form_state->getValue(['urls', 'action_url']);
-    $this->configuration['success_location'] = $form_state->getValue(['urls', 'success_location']);
-    $this->configuration['error_location'] = $form_state->getValue(['urls', 'error_location']);
     $this->configuration['field_list'] = $form_state->getValue(['fields', 'field_list']);
     $this->configuration['tracking_fields'] = $form_state->getValue(['fields', 'tracking_fields']);
     $this->configuration['submit_label'] = $form_state->getValue(['interface', 'submit_label']);
@@ -108,8 +94,6 @@ class PardotFormBlock extends BlockBase {
   public function defaultConfiguration() {
     return [
       'action_url' => 'https://go.pardot.com/l/102272/2016-11-04/2klckm',
-      'success_location' => 'https://extension.berkeley.edu/international/',
-      'error_location' => 'https://extension.berkeley.edu/international/',
       'field_list' => [
         'firstname' => 'firstname',
         'lastname' => 'lastname',
@@ -121,6 +105,8 @@ class PardotFormBlock extends BlockBase {
       'tracking_fields' => [
         'full_path' => 'full_path',
         'page_title' => 'page_title',
+        'success_location' => 'success_location',
+        'error_location' => 'error_location',
       ],
     ];
   }
@@ -145,7 +131,8 @@ class PardotFormBlock extends BlockBase {
     return [
       'full_path' => 'full_path',
       'page_title' => 'page_title',
-      'program_name' => 'program_name',
+      'success_location' => 'success_location',
+      'error_location' => 'error_location',
     ];
   }
 
@@ -190,8 +177,6 @@ class PardotFormBlock extends BlockBase {
     $build = [
       '#theme' => 'bglobal_pardot_form',
       '#action_url' => $this->configuration['action_url'],
-      '#success_location' => $this->configuration['success_location'],
-      '#error_location' => $this->configuration['error_location'],
       '#success_message' => $this->configuration['success_message'],
       '#submit_label' => $this->configuration['submit_label'],
     ];

--- a/web/modules/custom/bglobal_pardot/src/Plugin/Block/PardotFormBlock.php
+++ b/web/modules/custom/bglobal_pardot/src/Plugin/Block/PardotFormBlock.php
@@ -65,11 +65,8 @@ class PardotFormBlock extends BlockBase {
    * {@inheritdoc}
    */
   public function blockSubmit($form, FormStateInterface $form_state) {
-    // Process the block's submission handling if no errors occurred only.
-    if (!$form_state->getErrors()) {
-      foreach (array_keys($this->defaultConfiguration()) as $element) {
-        $this->configuration[$element] = $form_state->getValue($element);
-      }
+    foreach (array_keys($this->defaultConfiguration()) as $element) {
+      $this->configuration[$element] = $form_state->getValue($element);
     }
   }
 

--- a/web/modules/custom/bglobal_pardot/src/Plugin/Block/PardotFormBlock.php
+++ b/web/modules/custom/bglobal_pardot/src/Plugin/Block/PardotFormBlock.php
@@ -4,6 +4,7 @@ namespace Drupal\bglobal_pardot\Plugin\Block;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 
 /**
@@ -22,6 +23,83 @@ class PardotFormBlock extends BlockBase {
   public function access(AccountInterface $account, $return_as_object = FALSE) {
     $access = AccessResult::allowedIfHasPermission($account, 'access content');
     return $return_as_object ? $access : $access->isAllowed();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockForm($form, FormStateInterface $form_state) {
+    $form['urls'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Form URLs'),
+      '#open' => TRUE,
+    ];
+    $form['urls']['action_url'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Form Action URL'),
+      '#default_value' => $this->getDefaultValue('action_url'),
+      '#description' => $this->t('The Pardot form URL'),
+    ];
+    $form['urls']['success_location'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Success Location URL'),
+      '#default_value' => $this->getDefaultValue('success_location'),
+      '#description' => $this->t('The URL to redirect to after form completion.'),
+    ];
+    $form['urls']['error_location'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Error Location URL'),
+      '#default_value' => $this->getDefaultValue('error_location'),
+      '#description' => $this->t('The URL to redirect to on form failure.'),
+    ];
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockValidate($form, FormStateInterface $form_state) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockSubmit($form, FormStateInterface $form_state) {
+    // Process the block's submission handling if no errors occurred only.
+    if (!$form_state->getErrors()) {
+      foreach (array_keys($this->defaultConfiguration()) as $element) {
+        $this->configuration[$element] = $form_state->getValue($element);
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+      'action_url' => 'https://go.pardot.com/l/102272/2016-11-04/2klckm',
+      'success_location' => 'https://extension.berkeley.edu/international/',
+      'error_location' => 'https://extension.berkeley.edu/international/',
+      'field_list' => [],
+      'submit_label' => $this->t('Submit'),
+      'tracking_fields' => [],
+    ];
+  }
+
+  /**
+   * Returns the default value for a field,
+   *
+   * @param $field
+   *   The configuration field name.
+   *
+   * @return mixed
+   *   The value of the field as configured, or its default value.
+   */
+  public function getDefaultValue($field) {
+    $defaults = $this->defaultConfiguration();
+    $value = $this->configuration[$field] ?: $defaults[$field];
+    return $value;
   }
 
   /**


### PR DESCRIPTION
## Asana Ticket(s)
- See ticket [Pardot forms in Drupal](https://app.asana.com/0/1174970560648905/1196144381080481/f).

## Description
This PR makes the Pardot form block configurable, using default fields and settings for:

- firstname
- lastname
- email
- question
- joining the mailing list

## Testing instructions
1. Checkout this branch
2. Build the site
    * From inside the VM, run `/var/www/html/scripts/setup.sh` or `/var/www/html/scripts/refresh.sh` 
3. Observe the default Pardot form on the home page https://global.ddev.site/
4. Edit the block at https://global.ddev.site/admin/structure/block/manage/custompardotform
  - Deselect a field or two (like question, and opt_in_contact)
  - Change the Submit button label
5. Save the block
6. Reload the homepage and see your block changes.
 
## Remaining tasks

These can all be done in follow-up tickets.

- [ ] Update the README
- [ ] Settle on format for defining fields
- [ ] Determine what field settings are optional and what can be controlled (e.g. field_name, Label, Description, Required)
- [ ] Handle conditional fields -- this one is a bit out of scope for us
- [x] Handle success/error pages
- [ ] Handle whether the user can re-send the form or sees a thank you message -- this is a JS issue outside our scope.
