### PR TITLE
Configure pardot - reveal success and error location

### DIFF
--- a/config/drupal/block.block.custompardotform.yml
+++ b/config/drupal/block.block.custompardotform.yml
@@ -17,23 +17,19 @@ settings:
   label: 'Custom Pardot form'
   provider: bglobal_pardot
   label_display: visible
-  # What does adding the fields here do? 
-  # As I was debugging/learning I removed these and 
-  # it didn't seem to affect it
-  # 
-  # action_url: 'https://go.pardot.com/l/102272/2016-11-04/2klckm'
-  # success_location: 'https://extension.berkeley.edu/international/asdasd'
-  # error_location: 'https://extension.berkeley.edu/international/'
-  # field_list:
-  #   firstname: firstname
-  #   lastname: lastname
-  #   email: email
-  #   question: question
-  #   opt_in_contact: opt_in_contact
-  # submit_label: 'Apply Now'
-  # success_message: 'Success message...'
-  # tracking_fields:
-  #   full_path: full_path
-  #   page_title: page_title
-  #   program_name: 0
+  action_url: 'https://go.pardot.com/l/102272/2016-11-04/2klckm'
+  success_location: 'https://extension.berkeley.edu/international/'
+  error_location: 'https://extension.berkeley.edu/international/'
+  field_list:
+    firstname: firstname
+    lastname: lastname
+    email: email
+    question: question
+    opt_in_contact: opt_in_contact
+  submit_label: 'Apply Now'
+  success_message: 'Success message...'
+  tracking_fields:
+    full_path: full_path
+    page_title: page_title
+    program_name: 0
 visibility: {  }

--- a/config/drupal/block.block.custompardotform.yml
+++ b/config/drupal/block.block.custompardotform.yml
@@ -17,19 +17,23 @@ settings:
   label: 'Custom Pardot form'
   provider: bglobal_pardot
   label_display: visible
-  action_url: 'https://go.pardot.com/l/102272/2016-11-04/2klckm'
-  success_location: 'https://extension.berkeley.edu/international/asdasd'
-  error_location: 'https://extension.berkeley.edu/international/'
-  field_list:
-    firstname: firstname
-    lastname: lastname
-    email: email
-    question: question
-    opt_in_contact: opt_in_contact
-  submit_label: 'Apply Now'
-  success_message: 'Success message...'
-  tracking_fields:
-    full_path: full_path
-    page_title: page_title
-    program_name: 0
+  # What does adding the fields here do? 
+  # As I was debugging/learning I removed these and 
+  # it didn't seem to affect it
+  # 
+  # action_url: 'https://go.pardot.com/l/102272/2016-11-04/2klckm'
+  # success_location: 'https://extension.berkeley.edu/international/asdasd'
+  # error_location: 'https://extension.berkeley.edu/international/'
+  # field_list:
+  #   firstname: firstname
+  #   lastname: lastname
+  #   email: email
+  #   question: question
+  #   opt_in_contact: opt_in_contact
+  # submit_label: 'Apply Now'
+  # success_message: 'Success message...'
+  # tracking_fields:
+  #   full_path: full_path
+  #   page_title: page_title
+  #   program_name: 0
 visibility: {  }

--- a/web/modules/custom/bglobal_pardot/bglobal_pardot.module
+++ b/web/modules/custom/bglobal_pardot/bglobal_pardot.module
@@ -1,4 +1,5 @@
 <?php
+use Drupal\Core\Url;
 
 /**
  * @file
@@ -21,6 +22,8 @@ function bglobal_pardot_theme() {
           'page_title',
           'program_name',
           'full_path',
+          'success_location',
+          'error_location',
         ],
       ],
     ),
@@ -83,10 +86,13 @@ function bglobal_pardot_trackers() {
     $page_title = 'Berkeley Global';
   }
 
+  $current_url = Url::fromRoute('<current>', [], ['query' => \Drupal::request()->query->all(), 'absolute' => 'true'])->toString();
   $trackers = [
     'full_path' => 'This value needs to be derived from local storage and set as a script target object.',
     'page_title' => $page_title,
     'program_name' => '',
+    'success_location' => $current_url . "?thankyou=welcome",
+    'error_location' => $current_url . "?thankyou=false",
   ];
 
   return $trackers;

--- a/web/modules/custom/bglobal_pardot/src/Plugin/Block/PardotFormBlock.php
+++ b/web/modules/custom/bglobal_pardot/src/Plugin/Block/PardotFormBlock.php
@@ -40,18 +40,6 @@ class PardotFormBlock extends BlockBase {
       '#default_value' => $this->configuration['action_url'],
       '#description' => $this->t('The Pardot form URL'),
     ];
-    $form['urls']['success_location'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Success Location URL'),
-      '#default_value' => $this->configuration['success_location'],
-      '#description' => $this->t('The URL to redirect to after form completion.'),
-    ];
-    $form['urls']['error_location'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Error Location URL'),
-      '#default_value' => $this->configuration['error_location'],
-      '#description' => $this->t('The URL to redirect to on form failure.'),
-    ];
     $form['fields'] = [
       '#type' => 'details',
       '#title' => $this->t('Pardot Fields'),
@@ -94,8 +82,6 @@ class PardotFormBlock extends BlockBase {
    */
   public function blockSubmit($form, FormStateInterface $form_state) {
     $this->configuration['action_url'] = $form_state->getValue(['urls', 'action_url']);
-    $this->configuration['success_location'] = $form_state->getValue(['urls', 'success_location']);
-    $this->configuration['error_location'] = $form_state->getValue(['urls', 'error_location']);
     $this->configuration['field_list'] = $form_state->getValue(['fields', 'field_list']);
     $this->configuration['tracking_fields'] = $form_state->getValue(['fields', 'tracking_fields']);
     $this->configuration['submit_label'] = $form_state->getValue(['interface', 'submit_label']);
@@ -108,8 +94,6 @@ class PardotFormBlock extends BlockBase {
   public function defaultConfiguration() {
     return [
       'action_url' => 'https://go.pardot.com/l/102272/2016-11-04/2klckm',
-      'success_location' => 'https://extension.berkeley.edu/international/',
-      'error_location' => 'https://extension.berkeley.edu/international/',
       'field_list' => [
         'firstname' => 'firstname',
         'lastname' => 'lastname',
@@ -121,6 +105,8 @@ class PardotFormBlock extends BlockBase {
       'tracking_fields' => [
         'full_path' => 'full_path',
         'page_title' => 'page_title',
+        'success_location' => 'success_location',
+        'error_location' => 'error_location',
       ],
     ];
   }
@@ -145,7 +131,8 @@ class PardotFormBlock extends BlockBase {
     return [
       'full_path' => 'full_path',
       'page_title' => 'page_title',
-      'program_name' => 'program_name',
+      'success_location' => 'success_location',
+      'error_location' => 'error_location',
     ];
   }
 
@@ -190,8 +177,6 @@ class PardotFormBlock extends BlockBase {
     $build = [
       '#theme' => 'bglobal_pardot_form',
       '#action_url' => $this->configuration['action_url'],
-      '#success_location' => $this->configuration['success_location'],
-      '#error_location' => $this->configuration['error_location'],
       '#success_message' => $this->configuration['success_message'],
       '#submit_label' => $this->configuration['submit_label'],
     ];


### PR DESCRIPTION
## Reference PR
- See PR #25

## Description
success_location and error_location fields weren't showing up in the DOM. I used debugging to better understand how this module works.

Those two hidden fields currently work by having the current page url appended with a query string we use on Google Analytics to track lead form submissions. Currently that query is set to: `thankyou=welcome`. 

Because the success locations don't need to be specified as they follow this pattern throughout, I removed them from the block and added them to the tracker fields object. We might wanna change that object name to be more precise to something like: `hidden_fields` or `dynamic_fields`.

## Testing instructions
1. Checkout this branch
2. Build the site
    * From inside the VM, run `/var/www/html/scripts/setup.sh` or `/var/www/html/scripts/refresh.sh` 
3. Observe the default Pardot form on the home page https://global.ddev.site/
4. Check that success_location and error_location fields are in the DOM and populated with the page URL followed by "thankyou=welcome" or "thankyou=error".
