### PR TITLE
One column title custom layout

### DIFF
--- a/web/modules/custom/bglobal_layouts/bglobal_layouts.layouts.yml
+++ b/web/modules/custom/bglobal_layouts/bglobal_layouts.layouts.yml
@@ -1,3 +1,21 @@
+bglobal_onecol_section:
+  label: 'One column with section title'
+  path: layouts/onecol_section_title
+  template: layout--onecol-title-section
+  library: bglobal_layouts/onecol_title_section
+  class: '\Drupal\bglobal_layouts\Plugin\Layout\BGOneColumnLayout'
+  category: 'Columns: 1'
+  default_region: first
+  icon_map:
+    - [title]
+    - [first]
+    - [first]
+    - [first]
+  regions:
+    first:
+      label: First
+    second:
+      label: Second
 bglobal_twocol_section:
   label: 'Two column with section title'
   path: layouts/twocol_section_title

--- a/web/modules/custom/bglobal_layouts/bglobal_layouts.libraries.yml
+++ b/web/modules/custom/bglobal_layouts/bglobal_layouts.libraries.yml
@@ -1,3 +1,8 @@
+onecol_title_section:
+  version: VERSION
+  css:
+    theme:
+      layouts/onecol_section_title/bg_onecol_section.css: {}
 twocol_title_section:
   version: VERSION
   css:

--- a/web/modules/custom/bglobal_layouts/layouts/fourcol_section_title/layout--fourcol-title-section.html.twig
+++ b/web/modules/custom/bglobal_layouts/layouts/fourcol_section_title/layout--fourcol-title-section.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation for a three-column layout.
+ * Default theme implementation for a four-column layout.
  *
  * Available variables:
  * - content: The content for this layout.

--- a/web/modules/custom/bglobal_layouts/layouts/onecol_section_title/bg_onecol_section.css
+++ b/web/modules/custom/bglobal_layouts/layouts/onecol_section_title/bg_onecol_section.css
@@ -1,0 +1,4 @@
+/*
+ * @file
+ * Provides the layout styles for one-column layout section.
+ */

--- a/web/modules/custom/bglobal_layouts/layouts/onecol_section_title/layout--onecol-title-section.html.twig
+++ b/web/modules/custom/bglobal_layouts/layouts/onecol_section_title/layout--onecol-title-section.html.twig
@@ -1,0 +1,27 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a one-column layout.
+ *
+ * Available variables:
+ * - content: The content for this layout.
+ * - attributes: HTML attributes for the layout <div>.
+ *
+ * @ingroup themeable
+ */
+#}
+{% if content %}
+  <div{{ attributes.addClass(classes) }}>
+    <div class="container">
+      {% if content.title %}
+        <h2 class="section-title">{{ content.title }}</h2>
+      {% endif %}
+
+      {% if content.first %}
+        <div {{ region_attributes.first.addClass('layout__region', 'layout__region--first') }}>
+          {{ content.first }}
+        </div>
+      {% endif %}
+    </div>
+  </div>
+{% endif %}

--- a/web/modules/custom/bglobal_layouts/src/Plugin/Layout/BGFourColumnLayout.php
+++ b/web/modules/custom/bglobal_layouts/src/Plugin/Layout/BGFourColumnLayout.php
@@ -7,7 +7,7 @@ use Drupal\Core\Layout\LayoutDefault;
 use Drupal\Core\Render\Markup;
 
 /**
- * Configurable two column layout plugin class.
+ * Configurable four column layout plugin class.
  *
  * @internal
  *   Plugin classes are internal.

--- a/web/modules/custom/bglobal_layouts/src/Plugin/Layout/BGOneColumnLayout.php
+++ b/web/modules/custom/bglobal_layouts/src/Plugin/Layout/BGOneColumnLayout.php
@@ -3,20 +3,24 @@
 namespace Drupal\bglobal_layouts\Plugin\Layout;
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Layout\LayoutDefault;
 use Drupal\Core\Render\Markup;
-use Drupal\layout_builder\Plugin\Layout\ThreeColumnLayout;
 
 /**
- * Configurable three column layout plugin class.
+ * Configurable one column layout plugin class.
  *
  * @internal
  *   Plugin classes are internal.
  */
-class BGThreeColumnLayout extends ThreeColumnLayout {
+class BGOneColumnLayout extends LayoutDefault {
 
   public function build(array $regions) {
     $build = parent::build($regions);
-    $build['#attributes']['class'][] = 'title-layout';
+    $build['#attributes']['class'] = [
+      'layout',
+      'title-layout',
+      $this->getPluginDefinition()->getTemplate(),
+    ];
     $title = $this->getConfiguration()['title'] ?? '';
     if ($title) {
       $build['title'] = [


### PR DESCRIPTION
## Description
- Created custom one column section with title layout builder layout.

## Testing instructions
- Create a landing page in your local
- Add a section and confirm that one column with title exists
<img width="150" alt="Screen Shot 2020-11-04 at 2 54 48 PM" src="https://user-images.githubusercontent.com/10488517/98166848-b3d22000-1ead-11eb-9cf1-58183eb69fdf.png">

- Add the section, add a block, save and confirm that it looks as expected.
<img width="800" alt="Screen Shot 2020-11-04 at 2 52 15 PM" src="https://user-images.githubusercontent.com/10488517/98166893-c9474a00-1ead-11eb-88b5-e2b581a3d7f6.png">
