### PR TITLE
Fix bug that removed the edit pencil from custom blocks

### DIFF
--- a/web/themes/custom/bglobal/templates/blocks/block--full-time-curriculum-tabs.html.twig
+++ b/web/themes/custom/bglobal/templates/blocks/block--full-time-curriculum-tabs.html.twig
@@ -26,8 +26,8 @@
  */
 #}
 <div{{ attributes }}>
-  {# {{ title_prefix }}
-  {{ title_suffix }} #}
+  {{ title_prefix }}
+  {{ title_suffix }}
   {% block content %}
     {% include '@organisms/curriculum-tabs/curriculum-tabs.twig' with {
       'program': {

--- a/web/themes/custom/bglobal/templates/blocks/block--inline-block--full-width-background-image.html.twig
+++ b/web/themes/custom/bglobal/templates/blocks/block--inline-block--full-width-background-image.html.twig
@@ -26,8 +26,8 @@
  */
 #}
 <div{{ attributes }}>
-  {# {{ title_prefix }}
-  {{ title_suffix }} #}
+  {{ title_prefix }}
+  {{ title_suffix }}
   {% block content %}
     {% include '@molecules/full_width_background_image/full_width_background_image.twig' with {
       'img': {


### PR DESCRIPTION
Description
Addressing a few issues that came up during the demo with Sarah (content migration):

User access rights were too limited for the Editor position
The Pencil (edit/configure/remove) button wasn't present on custom blocks.
The Layout Builder sidebar styling was really weird. Turns out it was a widespread bug that arose about a month ago.